### PR TITLE
Issue #6 - support for custom headers

### DIFF
--- a/src/Shark.PdfConvert/PdfConversionSettings.cs
+++ b/src/Shark.PdfConvert/PdfConversionSettings.cs
@@ -155,6 +155,10 @@ namespace Shark.PdfConvert
         /// I've noticed some odd behavior with this ProcessStartInfo option enabled, so I'm making the default false
         /// </summary>
         public bool ProcessOptionRedirectStandardError { get; set; } = false;
+        /// <summary>
+        /// Key value pairs to be used for custom headers
+        /// </summary>
+        public Dictionary<string, string> CustomHeaders { get; set; } = new Dictionary<string, string>();
     }
 
     /// <summary>

--- a/src/Shark.PdfConvert/PdfConvert.cs
+++ b/src/Shark.PdfConvert/PdfConvert.cs
@@ -5,6 +5,7 @@
     using System.IO;
     using System.Diagnostics;
     using System.Linq;
+    using System.Collections.Generic;
 
     /// <summary>
     /// Pdf Conversion wrapping the WkHtmlToPdf tool
@@ -32,6 +33,12 @@
                 if (config.Size != PdfPageSize.Default) options.AppendFormat("--page-size {0} ", config.Size.ToString());
                 if (config.Orientation != PdfPageOrientation.Default) options.AppendFormat("--orientation {0} ", config.Orientation.ToString());
                 if (string.IsNullOrWhiteSpace(config.Title) == false) options.AppendFormat("--title \"{0}\" ", config.Title.Replace("\"", ""));
+
+                //iterate through custom headers
+                foreach (KeyValuePair<string, string> customHeader in config.CustomHeaders)
+                {
+                    options.AppendFormat("--custom-header \"{0}\" \"{1}\" ", customHeader.Key, customHeader.Value);
+                }
             }
             else
             {


### PR DESCRIPTION
Hi @cp79shark. I have done two small additions to your code to support my use case described in issue #6. First I have added a dictionary for custom headers to the settings class.  Later on, in PdfConvert class, I iterate through the dictionary object to create additional options for WkHtmlToPdf tool. I have used this solution for the authorization header to pass a bearer token together with my request and it works perfectly fine. I have tested it with other headers types as well, and also tested adding multiple headers at the same time. 

This is an example of using it:
`settings.CustomHeaders.Add("Authorization", $"Bearer {accessToken}");`