### PR TITLE
Fix missing usage of the quiet config

### DIFF
--- a/src/Shark.PdfConvert/PdfConvert.cs
+++ b/src/Shark.PdfConvert/PdfConvert.cs
@@ -38,6 +38,8 @@
                 if (config.Orientation != PdfPageOrientation.Default) options.AppendFormat("--orientation {0} ", config.Orientation.ToString());
                 if (string.IsNullOrWhiteSpace(config.Title) == false) options.AppendFormat("--title \"{0}\" ", config.Title.Replace("\"", ""));
 
+                if (config.Quiet) options.Append("--quiet ");
+
                 //iterate through custom headers
                 foreach (KeyValuePair<string, string> customHeader in config.CustomHeaders)
                 {


### PR DESCRIPTION
Wkhtmltopdf was logging messages during pdf generation even though the Quiet config of Shark.PdfConvert should default to true and was explicitly set to true in my project.

I looked at the source code and to me it appears the Quiet config setting isn't used in generating commandline arguments for wkhtmltopdf?!

This PR intends to add the `--quiet` parameter if Quiet is set to true.

Note: This will use the `--quiet` parameter instead of the newer `--log-level none`, so that Shark.PdfConvert isnt tied to wkhtmltopdf 0.12.5+. Newer releases of wkhtmltopdf luckily still support the `--quiet` parameter for backwards-compatibility.